### PR TITLE
php7 new obj by ref

### DIFF
--- a/src/figdice/classes/ViewElementTag.php
+++ b/src/figdice/classes/ViewElementTag.php
@@ -2,7 +2,7 @@
 /**
  * @author Gabriel Zerbib <gabriel@figdice.org>
  * @copyright 2004-2016, Gabriel Zerbib.
- * @version 2.3.2
+ * @version 2.3.3
  * @package FigDice
  *
  * This file is part of FigDice.
@@ -106,7 +106,7 @@ class ViewElementTag extends ViewElement {
 	 * @param string $name
 	 * @param integer $xmlLineNumber
 	 */
-	public function __construct(View &$view, $name, $xmlLineNumber) {
+	public function __construct(View $view, $name, $xmlLineNumber) {
 		parent::__construct($view);
 		$this->name = $name;
 		$this->attributes = array();

--- a/src/figdice/classes/lexer/Lexer.php
+++ b/src/figdice/classes/lexer/Lexer.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * @author Gabriel Zerbib <gabriel@figdice.org>
- * @copyright 2004-2015, Gabriel Zerbib.
- * @version 2.1.2
+ * @copyright 2004-2016, Gabriel Zerbib.
+ * @version 2.3.3
  * @package FigDice
  *
  * This file is part of FigDice.
@@ -24,6 +24,7 @@
 namespace figdice\classes\lexer;
 
 use figdice\classes\File;
+use figdice\classes\ViewElement;
 use \figdice\classes\ViewElementTag;
 use \figdice\exceptions\LexerUnexpectedCharException;
 use \figdice\exceptions\LexerSyntaxErrorException;

--- a/test/LexerTest.php
+++ b/test/LexerTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * @author Gabriel Zerbib <gabriel@figdice.org>
- * @copyright 2004-2015, Gabriel Zerbib.
- * @version 2.1.1
+ * @copyright 2004-2016, Gabriel Zerbib.
+ * @version 2.3.3
  * @package FigDice
  *
  * This file is part of FigDice.
@@ -22,9 +22,7 @@
  */
 
 use figdice\classes\lexer\Lexer;
-use figdice\exceptions\LexerUnexpectedCharException;
 use figdice\View;
-use figdice\classes\File;
 use figdice\classes\ViewElementTag;
 
 /**


### PR DESCRIPTION
Passing by reference a View object to constructor of ViewElementTag is not relevant.
For some time in PHP, an object is always passed by reference.
See http://php.net/manual/en/functions.arguments.php#119724